### PR TITLE
fix: prevent to show oversized product images when they have portrait ratio

### DIFF
--- a/components/Cart/Summary/index.tsx
+++ b/components/Cart/Summary/index.tsx
@@ -34,7 +34,7 @@ export const Summary: FC<Props> = ({ className, listTypes }) => {
           >
             <LineItemImage
               width={170}
-              className="w-1/4 self-start md:self-center"
+              className="w-1/4 self-start md:self-center max-h-44 object-contain"
             />
 
             <div className="flex-1 flex flex-col min-h-[150px]">


### PR DESCRIPTION
### What does this PR do?

This fixes the issue we might have with tall images, where height is much higher than their width.
Now we enforce a max height and keep the image contained.

### Screenshots (Optional)

<img width="761" alt="image" src="https://user-images.githubusercontent.com/30926550/178536438-c8b00a2c-da1a-4e6e-a161-03014024fd85.png">
