### PR TITLE
Add support for organization-config

### DIFF
--- a/packages/cart/@typing/Settings.d.ts
+++ b/packages/cart/@typing/Settings.d.ts
@@ -1,4 +1,6 @@
 declare module "HostedApp" {
+  import { DefaultConfig } from "@commercelayer/organization-config"
+
   export type Settings = {
     /**
      * Access Token for a sales channel API credentials to be used to authenticate all Commerce Layer API requests.
@@ -63,6 +65,10 @@ declare module "HostedApp" {
      * Total items found in current order.
      */
     itemsCount: number
+    /**
+     * The organization configuration object that overrides the default settings by market and language.
+     */
+    organizationConfig: DefaultConfig | null
   }
 
   export type InvalidSettings = Pick<

--- a/packages/cart/package.json
+++ b/packages/cart/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@commercelayer/js-auth": "^6.3.1",
     "@commercelayer/organization-config": "^1.4.8",
-    "@commercelayer/react-components": "^4.15.1",
+    "@commercelayer/react-components": "^4.15.3",
     "@commercelayer/react-utils": "1.0.0-beta.3",
     "@commercelayer/sdk": "6.9.0",
     "@playwright/test": "^1.45.3",

--- a/packages/cart/package.json
+++ b/packages/cart/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@commercelayer/js-auth": "^6.3.1",
+    "@commercelayer/organization-config": "^1.4.8",
     "@commercelayer/react-components": "^4.15.1",
     "@commercelayer/react-utils": "1.0.0-beta.3",
     "@commercelayer/sdk": "6.9.0",

--- a/packages/cart/src/components/SettingsProvider.tsx
+++ b/packages/cart/src/components/SettingsProvider.tsx
@@ -39,7 +39,7 @@ type SettingsProviderProps = {
   /**
    * App config served locally from public/config.js
    */
-  config: CommerceLayerAppConfig
+  appConfig: CommerceLayerAppConfig
   /**
    * If needed, context value can be also accessed using a function as a child.
    *
@@ -72,7 +72,7 @@ export const useSettings = (): SettingsProviderValue => {
 export const SettingsProvider: FC<SettingsProviderProps> = ({
   orderId,
   children,
-  config,
+  appConfig,
 }) => {
   const [settings, setSettings] = useState<Settings | InvalidSettings>(
     defaultSettings
@@ -84,7 +84,7 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({
     setIsLoading(!!accessToken)
 
     if (accessToken) {
-      getSettings({ orderId, accessToken, config })
+      getSettings({ orderId, accessToken, appConfig })
         .then(setSettings)
         .finally(() => {
           setIsLoading(false)

--- a/packages/cart/src/pages/CartPage.tsx
+++ b/packages/cart/src/pages/CartPage.tsx
@@ -19,7 +19,7 @@ function CartPage(): JSX.Element {
   const { t } = useTranslation()
   const orderId = params?.orderId
 
-  const config = {
+  const appConfig = {
     ...window.clAppConfig,
     selfHostedSlug:
       // local config is always overwritten by ENV var, if present
@@ -33,7 +33,7 @@ function CartPage(): JSX.Element {
   }
 
   return (
-    <SettingsProvider orderId={orderId} config={config}>
+    <SettingsProvider orderId={orderId} appConfig={appConfig}>
       {({ settings, isLoading }) => (
         <GlobalStylesProvider primaryColor={settings.primaryColor}>
           {isLoading ? (

--- a/packages/cart/src/utils/getInfoFromJwt.ts
+++ b/packages/cart/src/utils/getInfoFromJwt.ts
@@ -15,6 +15,9 @@ type JWTProps = {
   application: {
     kind: string
   }
+  market: {
+    id: string[]
+  }
   /**
    * If `true` it means the  Organization is working in test mode and live mode is not enabled.
    */
@@ -34,9 +37,9 @@ export const getInfoFromJwt = (accessToken: string) => {
       organization: { slug },
       application: { kind },
       test,
+      market,
     } = jwtDecode(accessToken) as JWTProps
-
-    return { slug, kind, isTest: test }
+    return { slug, kind, isTest: test, market }
   } catch (e) {
     return {}
   }

--- a/packages/cart/src/utils/getOrderDetails.ts
+++ b/packages/cart/src/utils/getOrderDetails.ts
@@ -34,8 +34,6 @@ const getAsyncOrder = async (client: CommerceLayerClient, orderId: string) => {
         "number",
         "guest",
         "language_code",
-        "terms_url",
-        "privacy_url",
         "return_url",
         "cart_url",
         "line_items",

--- a/packages/cart/src/utils/getOrganizationDetails.ts
+++ b/packages/cart/src/utils/getOrganizationDetails.ts
@@ -31,6 +31,7 @@ const getAsyncOrganization = async (client: CommerceLayerClient) => {
         "favicon_url",
         "gtm_id",
         "gtm_id_test",
+        "config",
       ],
     },
   })

--- a/packages/cart/src/utils/updateAccessTokenInUrl.test.ts
+++ b/packages/cart/src/utils/updateAccessTokenInUrl.test.ts
@@ -1,0 +1,48 @@
+import { updateAccessTokenInUrl } from "./updateAccessTokenInUrl"
+
+describe("updateAccessTokenInUrl", () => {
+  it("should update the access token in the URL", () => {
+    const result = updateAccessTokenInUrl({
+      cartUrl: "https://example.com/cart?accessToken=oldAccessToken",
+      accessToken: "newAccessToken",
+    })
+    expect(result).toBe("https://example.com/cart?accessToken=newAccessToken")
+  })
+
+  it("should keep existing query parameters", () => {
+    const result = updateAccessTokenInUrl({
+      cartUrl:
+        "https://example.com/cart?foo=bar&accessToken=oldAccessToken&user=123",
+      accessToken: "newAccessToken",
+    })
+
+    expect(result).toBe(
+      "https://example.com/cart?foo=bar&accessToken=newAccessToken&user=123"
+    )
+  })
+
+  it("should return same url, if accessToken does not exists", () => {
+    const result = updateAccessTokenInUrl({
+      cartUrl: "https://example.com/cart?foo=bar",
+      accessToken: "newAccessToken",
+    })
+
+    expect(result).toBe("https://example.com/cart?foo=bar")
+  })
+
+  it("should return undefined if cartUrl is not valid or empty", () => {
+    expect(
+      updateAccessTokenInUrl({
+        cartUrl: "http//broken-url?accessToken=123",
+        accessToken: "",
+      })
+    ).toBe(undefined)
+
+    expect(
+      updateAccessTokenInUrl({
+        cartUrl: "",
+        accessToken: "abc",
+      })
+    ).toBe(undefined)
+  })
+})

--- a/packages/cart/src/utils/updateAccessTokenInUrl.ts
+++ b/packages/cart/src/utils/updateAccessTokenInUrl.ts
@@ -1,0 +1,20 @@
+/**
+ * Update the access token in the URL, if it exists as query parameter.
+ */
+export function updateAccessTokenInUrl({
+  cartUrl,
+  accessToken,
+}: {
+  cartUrl: string
+  accessToken: string
+}) {
+  try {
+    const url = new URL(cartUrl)
+    if (url.searchParams.has("accessToken")) {
+      url.searchParams.set("accessToken", accessToken)
+    }
+    return url.toString()
+  } catch {
+    return undefined
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.4.8
         version: 1.4.8(eslint@8.57.0)(typescript@5.5.4)
       '@commercelayer/react-components':
-        specifier: ^4.15.1
-        version: 4.15.1(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        specifier: ^4.15.3
+        version: 4.15.3(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@commercelayer/react-utils':
         specifier: 1.0.0-beta.3
         version: 1.0.0-beta.3(@semantic-release/changelog@6.0.2(semantic-release@19.0.5(encoding@0.1.13)))(@semantic-release/commit-analyzer@9.0.2(semantic-release@19.0.5(encoding@0.1.13)))(@semantic-release/git@10.0.1(semantic-release@19.0.5(encoding@0.1.13)))(@semantic-release/github@8.0.7(encoding@0.1.13)(semantic-release@19.0.5(encoding@0.1.13)))(@semantic-release/npm@9.0.1(semantic-release@19.0.5(encoding@0.1.13)))(@semantic-release/release-notes-generator@10.0.3(semantic-release@19.0.5(encoding@0.1.13)))(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)(semantic-release@19.0.5(encoding@0.1.13))(tailwindcss@3.4.7)
@@ -407,8 +407,8 @@ packages:
       eslint: '>=8.0'
       typescript: '>=5.0'
 
-  '@commercelayer/react-components@4.15.1':
-    resolution: {integrity: sha512-i/e6rK2xLbdp9KK+tRXznGaFsqHMgO44Ctqa+IReIyafH4bzXVRdQheLu9a2KizmJ6ll1T6QKnk1q6DDdTP4Xw==}
+  '@commercelayer/react-components@4.15.3':
+    resolution: {integrity: sha512-NqN+79kR/fbMHGTwAFYt3G0PkNv7ZjNl0/i3S7bTbOKQQUpUMZODmeQrU2VTJz3wH734xVLeOP0b2X57uyQ3Qg==}
     peerDependencies:
       react: '>=18.0.0'
 
@@ -5705,7 +5705,7 @@ snapshots:
 
   '@adyen/adyen-web@5.67.0':
     dependencies:
-      '@babel/runtime': 7.23.9
+      '@babel/runtime': 7.25.0
       '@babel/runtime-corejs3': 7.20.6
       '@types/applepayjs': 14.0.6
       '@types/googlepay': 0.7.6
@@ -5981,7 +5981,7 @@ snapshots:
       merge-anything: 5.1.7
       typescript: 5.5.4
 
-  '@commercelayer/react-components@4.15.1(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@commercelayer/react-components@4.15.3(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
       '@adyen/adyen-web': 5.67.0
       '@commercelayer/organization-config': 1.4.8(eslint@8.57.0)(typescript@5.5.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@commercelayer/js-auth':
         specifier: ^6.3.1
         version: 6.3.1
+      '@commercelayer/organization-config':
+        specifier: ^1.4.8
+        version: 1.4.8(eslint@8.57.0)(typescript@5.5.4)
       '@commercelayer/react-components':
         specifier: ^4.15.1
         version: 4.15.1(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)


### PR DESCRIPTION
Closes #73 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- [x] If `order.cart_url` is not set, the app tries to use the rule defined in the organization config (if present)
- [x] When an existing `cart_url` is found and contains an old accessToken, it will be updated with the current one
- [x] Predilige `checkout_url` from organization config (if present)


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
