### PR TITLE
Hide  'continue shopping' button when embedded as iframe

### DIFF
--- a/packages/cart/specs/e2e/embedded.spec.ts
+++ b/packages/cart/specs/e2e/embedded.spec.ts
@@ -18,8 +18,8 @@ test.describe("Enter the page as embedded", () => {
 
   test("should have iframe capabilities", async ({ CartPage }) => {
     await expect(
-      CartPage.page.locator(`[data-test-id=return-url][target=_top]`)
-    ).toBeVisible()
+      CartPage.page.locator(`[data-test-id=return-url]`)
+    ).not.toBeVisible()
     await expect(
       CartPage.page.locator(`[data-test-id=button-checkout][target=_top]`)
     ).toBeVisible()

--- a/packages/cart/src/components/Cart/Summary/index.tsx
+++ b/packages/cart/src/components/Cart/Summary/index.tsx
@@ -89,13 +89,12 @@ export const Summary: FC<Props> = ({ listTypes }) => {
       </LineItemsEmpty>
 
       {/* Return Url */}
-      {settings.isValid && settings.returnUrl ? (
+      {settings.isValid && settings.returnUrl && !isEmbedded() ? (
         <div className="pt-2 pb-8">
           <a
             data-test-id="return-url"
             href={settings.returnUrl}
             className="link-base text-xs font-bold"
-            target={isEmbedded() ? "_top" : undefined}
           >
             &lt; {t("general.returnUrlLabel")}
           </a>


### PR DESCRIPTION
## What I did

When cart is loaded within an iframe, the "continue shopping" button is redundant and not required.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
