### PR TITLE
Use organization-config to retrieve default language

### DIFF
--- a/packages/cart/@typing/Settings.d.ts
+++ b/packages/cart/@typing/Settings.d.ts
@@ -1,5 +1,5 @@
 declare module "HostedApp" {
-  import { DefaultConfig } from "@commercelayer/organization-config"
+  import type { DefaultConfig } from "@commercelayer/organization-config"
 
   export type Settings = {
     /**

--- a/packages/cart/package.json
+++ b/packages/cart/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@commercelayer/js-auth": "^6.7.1",
-    "@commercelayer/organization-config": "^1.4.12",
+    "@commercelayer/organization-config": "^2.1.0",
     "@commercelayer/react-components": "4.19.0",
     "@commercelayer/react-utils": "1.0.0-beta.3",
     "@commercelayer/sdk": "6.32.0",

--- a/packages/cart/src/components/SettingsProvider.tsx
+++ b/packages/cart/src/components/SettingsProvider.tsx
@@ -79,6 +79,7 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({
   )
   const [isLoading, setIsLoading] = useState(true)
   const accessToken = getAccessTokenFromUrl()
+  const language = settings.language
 
   useEffect(() => {
     setIsLoading(!!accessToken)
@@ -94,10 +95,10 @@ export const SettingsProvider: FC<SettingsProviderProps> = ({
 
   // keep i18n in sync
   useEffect(() => {
-    if (settings.language) {
-      changeLanguage(parseLanguageCode(settings.language))
+    if (language) {
+      changeLanguage(parseLanguageCode(language))
     }
-  }, [settings.language])
+  }, [language])
 
   const value = { settings, isLoading }
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^6.7.1
         version: 6.7.1
       '@commercelayer/organization-config':
-        specifier: ^1.4.12
-        version: 1.4.12
+        specifier: ^2.1.0
+        version: 2.1.0
       '@commercelayer/react-components':
         specifier: 4.19.0
         version: 4.19.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.8)(typescript@5.7.3)
@@ -330,12 +330,8 @@ packages:
     resolution: {integrity: sha512-GOfOGeLKhdjKa1qTq2KTF14rEKYYX7yvUYH1GYc4YuX3d5DNLqwQJK4eJN054GnAYl4YeyimVSqmLhiwC5OfBA==}
     engines: {node: '>=18.0.0'}
 
-  '@commercelayer/organization-config@1.4.12':
-    resolution: {integrity: sha512-tGSKEg8X3LjPaFbahYt8vXSbaOmAE5toR6VGOt6aCO6oRdlkJAeKUuNur8A6531Peth7sAuxOXg54I1UMp5iqA==}
-    engines: {node: '>=18', pnpm: '>=7'}
-
-  '@commercelayer/organization-config@2.0.2':
-    resolution: {integrity: sha512-MAVc21ySdfIbredKX1Ut7X//euZ8Wbu+iDoJmnjmQTp+3yJJi2DZwUeJOBbtrEfH1LnDdJUIrUZYB4LappZztw==}
+  '@commercelayer/organization-config@2.1.0':
+    resolution: {integrity: sha512-Q1heKsaJfQfK0eEOV5hOdDUAQG1e+I+kP1VZVvgaufqDPcsHjhfRzhLuS7E9DBzOmXrSrpeMFEynqt5nzoTgcA==}
     engines: {node: '>=18', pnpm: '>=7'}
 
   '@commercelayer/react-components@4.19.0':
@@ -4353,18 +4349,14 @@ snapshots:
 
   '@commercelayer/js-auth@6.7.1': {}
 
-  '@commercelayer/organization-config@1.4.12':
-    dependencies:
-      merge-anything: 5.1.7
-
-  '@commercelayer/organization-config@2.0.2':
+  '@commercelayer/organization-config@2.1.0':
     dependencies:
       merge-anything: 5.1.7
 
   '@commercelayer/react-components@4.19.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.8)(typescript@5.7.3)':
     dependencies:
       '@adyen/adyen-web': 6.8.0
-      '@commercelayer/organization-config': 2.0.2
+      '@commercelayer/organization-config': 2.1.0
       '@commercelayer/sdk': 6.32.0
       '@stripe/react-stripe-js': 3.1.1(@stripe/stripe-js@5.6.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@stripe/stripe-js': 5.6.0


### PR DESCRIPTION
## What I did

When `order.language` is not accessibile, default language is retrieved from the organization config.
If organization config is not available, then the browser language will be used.



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
