### PR TITLE
Update PaymentMethod component to conditionally hide non-stripe payment sources

### DIFF
--- a/packages/cart/src/components/Cart/Totals/ButtonCheckout.tsx
+++ b/packages/cart/src/components/Cart/Totals/ButtonCheckout.tsx
@@ -9,7 +9,6 @@ import {
 } from "@commercelayer/react-components"
 import type { FC } from "react"
 import { useTranslation } from "react-i18next"
-
 import { ButtonCheckoutDisabled } from "#components/atoms/ButtonCheckoutDisabled"
 import { isEmbedded } from "#utils/isEmbedded"
 
@@ -22,7 +21,15 @@ export const ButtonCheckout: FC = () => {
     <>
       <div key={order?.total_amount_cents}>
         <PaymentMethodsContainer>
-          <PaymentMethod expressPayments className="mb-4" loader={<div />}>
+          <PaymentMethod
+            expressPayments
+            className="mb-4"
+            loader={<div />}
+            hide={({ payment_source_type }) => {
+              // only show stripe payments
+              return payment_source_type === "stripe_payments"
+            }}
+          >
             <PaymentSource loader={<div />} />
           </PaymentMethod>
         </PaymentMethodsContainer>


### PR DESCRIPTION
## What I did

This pull request includes changes to the `ButtonCheckout` component in the `packages/cart/src/components/Cart/Totals/ButtonCheckout.tsx` file. The most important changes focus on improving the display logic for payment methods.

Changes to `ButtonCheckout` component:

* Added a `hide` function to the `PaymentMethod` component to filter and only show Stripe payment methods.

Code cleanup:

* Removed an unnecessary blank line in the import statements.
## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
