### PR TITLE
Add support for 4 additional languages

### DIFF
--- a/packages/cart/@typing/react-i18next.d.ts
+++ b/packages/cart/@typing/react-i18next.d.ts
@@ -2,7 +2,7 @@ import "react-i18next"
 import commonEn from "#assets/locales/en/common.json"
 
 declare module "react-i18next" {
-  export type AllowedLocaleKeys = "en" | "it" | "de" | "pl" | "hu" | "pt" | "nl"
+  export type AllowedLocaleKeys = "en" | "it" | "de" | "pl" | "hu" | "pt" | "nl" | "es" | "fr" | "hr" | "sl"
 
   type AppResources = {
     common: typeof commonEn

--- a/packages/cart/specs/e2e/language.spec.ts
+++ b/packages/cart/specs/e2e/language.spec.ts
@@ -103,3 +103,55 @@ test.describe("Cart in Dutch", () => {
     await CartPage.checkOrderLanguage("nl")
   })
 })
+
+test.describe("Cart in Spanish", () => {
+  test.use({
+    options: {
+      orderType: "plain",
+      attributes: { language_code: "es" },
+    },
+  })
+
+  test("should open a cart with texts in Spanish", async ({ CartPage }) => {
+    await CartPage.checkOrderLanguage("es")
+  })
+})
+
+test.describe("Cart in French", () => {
+  test.use({
+    options: {
+      orderType: "plain",
+      attributes: { language_code: "fr" },
+    },
+  })
+
+  test("should open a cart with texts in French", async ({ CartPage }) => {
+    await CartPage.checkOrderLanguage("fr")
+  })
+})
+
+test.describe("Cart in Croatian", () => {
+  test.use({
+    options: {
+      orderType: "plain",
+      attributes: { language_code: "hr" },
+    },
+  })
+
+  test("should open a cart with texts in Croatian", async ({ CartPage }) => {
+    await CartPage.checkOrderLanguage("hr")
+  })
+})
+
+test.describe("Cart in Slovenian", () => {
+  test.use({
+    options: {
+      orderType: "plain",
+      attributes: { language_code: "sl" },
+    },
+  })
+
+  test("should open a cart with texts in Slovenian", async ({ CartPage }) => {
+    await CartPage.checkOrderLanguage("sl")
+  })
+})

--- a/packages/cart/specs/fixtures/CartPage.ts
+++ b/packages/cart/specs/fixtures/CartPage.ts
@@ -2,11 +2,15 @@ import { expect, type Locator, type Page } from "@playwright/test"
 
 import commonDe from "#assets/locales/de/common.json"
 import commonEn from "#assets/locales/en/common.json"
+import commonEs from "#assets/locales/es/common.json"
+import commonFr from "#assets/locales/fr/common.json"
+import commonHr from "#assets/locales/hr/common.json"
 import commonHu from "#assets/locales/hu/common.json"
 import commonIt from "#assets/locales/it/common.json"
 import commonNl from "#assets/locales/nl/common.json"
 import commonPl from "#assets/locales/pl/common.json"
 import commonPt from "#assets/locales/pt/common.json"
+import commonSl from "#assets/locales/sl/common.json"
 
 type GoToProps = {
   orderId: string
@@ -61,7 +65,7 @@ export class CartPage {
   }
 
   async checkOrderLanguage(
-    language: "en" | "it" | "de" | "hu" | "pl" | "pt" | "nl",
+    language: "en" | "it" | "de" | "hu" | "pl" | "pt" | "nl" | "es" | "fr" | "hr" | "sl",
   ) {
     const translations = {
       it: commonIt,
@@ -71,6 +75,10 @@ export class CartPage {
       pl: commonPl,
       pt: commonPt,
       nl: commonNl,
+      es: commonEs,
+      fr: commonFr,
+      hr: commonHr,
+      sl: commonSl,
     }
     const currentLang = translations[language]
     await expect(

--- a/packages/cart/src/assets/locales/es/common.json
+++ b/packages/cart/src/assets/locales/es/common.json
@@ -1,0 +1,55 @@
+{
+  "general": {
+    "title": "Carrito",
+    "itemsTitle": "Tus artículos",
+    "cartContains": "Tu carrito de compras contiene",
+    "item": "artículo",
+    "item_other": "artículos",
+    "emptyCart": "Tu carrito está vacío",
+    "remove": "Eliminar",
+    "price": "Precio unitario",
+    "finalPriceInCheckoutText": "Los impuestos y gastos de envío aplicables se calcularán en el checkout",
+    "subtotal": "Subtotal",
+    "discount": "Descuento",
+    "giftCard": "Tarjeta de regalo",
+    "shippingAmount": "Envío",
+    "paymentMethodAmount": "Método de pago",
+    "total": "Total",
+    "gotToCheckoutCta": "Pago",
+    "returnUrlLabel": "Continuar comprando",
+    "quantityNotAvailable": "La cantidad seleccionada no está disponible",
+    "retryableErrorCode": "Problemas de conectividad",
+    "retryableErrorDescription": "Intenta recargar la página"
+  },
+  "item": {
+    "frequency": {
+      "hourly": "Cada hora",
+      "daily": "Diario",
+      "weekly": "Semanal",
+      "monthly": "Mensual",
+      "two-months": "Cada dos meses",
+      "two-month": "Cada dos meses",
+      "three-months": "Cada tres meses",
+      "three-month": "Cada tres meses",
+      "four-months": "Cada cuatro meses",
+      "four-month": "Cada cuatro meses",
+      "six-months": "Cada seis meses",
+      "six-month": "Cada seis meses",
+      "yearly": "Anual"
+    }
+  },
+  "couponOrGift": {
+    "label": "¿Tienes un código promocional?",
+    "submit": "Aplicar",
+    "placeholder": {
+      "gift_card_or_coupon_code": "Código de tarjeta de regalo o cupón",
+      "gift_card_code": "Tarjeta de regalo",
+      "coupon_code": "Código de cupón"
+    },
+    "error": {
+      "gift_card_or_coupon_code": "Por favor, introduce un cupón o tarjeta de regalo válidos",
+      "gift_card_code": "Por favor, introduce una tarjeta de regalo válida",
+      "coupon_code": "Por favor, introduce un cupón válido"
+    }
+  }
+}

--- a/packages/cart/src/assets/locales/fr/common.json
+++ b/packages/cart/src/assets/locales/fr/common.json
@@ -1,0 +1,55 @@
+{
+  "general": {
+    "title": "Panier",
+    "itemsTitle": "Vos articles",
+    "cartContains": "Votre panier contient",
+    "item": "article",
+    "item_other": "articles",
+    "emptyCart": "Votre panier est vide",
+    "remove": "Supprimer",
+    "price": "Prix unitaire",
+    "finalPriceInCheckoutText": "Les taxes et frais de livraison applicables seront calculés lors du paiement",
+    "subtotal": "Sous-total",
+    "discount": "Réduction",
+    "giftCard": "Carte cadeau",
+    "shippingAmount": "Livraison",
+    "paymentMethodAmount": "Mode de paiement",
+    "total": "Total",
+    "gotToCheckoutCta": "Commander",
+    "returnUrlLabel": "Poursuivre ses achats",
+    "quantityNotAvailable": "La quantité sélectionnée n'est pas disponible",
+    "retryableErrorCode": "Problème de connexion",
+    "retryableErrorDescription": "Essayez de recharger la page"
+  },
+  "item": {
+    "frequency": {
+      "hourly": "Chaque heure",
+      "daily": "Chaque jour",
+      "weekly": "Chaque semaine",
+      "monthly": "Chaque mois",
+      "two-months": "Tous les deux mois",
+      "two-month": "Tous les deux mois",
+      "three-months": "Tous les trois mois",
+      "three-month": "Tous les trois mois",
+      "four-months": "Tous les quatre mois",
+      "four-month": "Tous les quatre mois",
+      "six-months": "Tous les six mois",
+      "six-month": "Tous les six mois",
+      "yearly": "Chaque année"
+    }
+  },
+  "couponOrGift": {
+    "label": "Vous avez un code promo ?",
+    "submit": "Appliquer",
+    "placeholder": {
+      "gift_card_or_coupon_code": "Carte cadeau ou code promo",
+      "gift_card_code": "Code carte cadeau",
+      "coupon_code": "Code promotionnel"
+    },
+    "error": {
+      "gift_card_or_coupon_code": "Veuillez saisir une carte cadeau ou un bon de réduction valide",
+      "gift_card_code": "Veuillez saisir une carte cadeau valide",
+      "coupon_code": "Veuillez saisir un bon de réduction valide"
+    }
+  }
+}

--- a/packages/cart/src/assets/locales/hr/common.json
+++ b/packages/cart/src/assets/locales/hr/common.json
@@ -1,0 +1,55 @@
+{
+  "general": {
+    "title": "Košarica",
+    "itemsTitle": "Vaši artikli",
+    "cartContains": "Vaša košarica sadrži",
+    "item": "artikl",
+    "item_other": "artikala",
+    "emptyCart": "Vaša košarica je prazna",
+    "remove": "Ukloni",
+    "price": "Jedinična cijena",
+    "finalPriceInCheckoutText": "Sve primjenjive poreze i troškove dostave izračunat ćemo na blagajni",
+    "subtotal": "Međuzbroj",
+    "discount": "Popust",
+    "giftCard": "Poklon kartica",
+    "shippingAmount": "Dostava",
+    "paymentMethodAmount": "Način plaćanja",
+    "total": "Ukupno",
+    "gotToCheckoutCta": "Blagajna",
+    "returnUrlLabel": "Nastavi s kupnjom",
+    "quantityNotAvailable": "Odabrana količina nije dostupna",
+    "retryableErrorCode": "Problemi s povezivanjem",
+    "retryableErrorDescription": "Pokušajte ponovno učitati stranicu"
+  },
+  "item": {
+    "frequency": {
+      "hourly": "Svakog sata",
+      "daily": "Dnevno",
+      "weekly": "Tjedno",
+      "monthly": "Mjesečno",
+      "two-months": "Svakih dva mjeseca",
+      "two-month": "Svakih dva mjeseca",
+      "three-months": "Svakih tri mjeseca",
+      "three-month": "Svakih tri mjeseca",
+      "four-months": "Svakih četiri mjeseca",
+      "four-month": "Svakih četiri mjeseca",
+      "six-months": "Svakih šest mjeseci",
+      "six-month": "Svakih šest mjeseci",
+      "yearly": "Godišnje"
+    }
+  },
+  "couponOrGift": {
+    "label": "Imate promotivni kod?",
+    "submit": "Primijeni",
+    "placeholder": {
+      "gift_card_or_coupon_code": "Kod poklon kartice ili kupona",
+      "gift_card_code": "Kod poklon kartice",
+      "coupon_code": "Kod kupona"
+    },
+    "error": {
+      "gift_card_or_coupon_code": "Unesite valjanu poklon karticu ili kupon",
+      "gift_card_code": "Unesite valjanu poklon karticu",
+      "coupon_code": "Unesite valjani kupon"
+    }
+  }
+}

--- a/packages/cart/src/assets/locales/sl/common.json
+++ b/packages/cart/src/assets/locales/sl/common.json
@@ -1,0 +1,55 @@
+{
+  "general": {
+    "title": "Košarica",
+    "itemsTitle": "Vaši izdelki",
+    "cartContains": "Vaša košarica vsebuje",
+    "item": "izdelek",
+    "item_other": "izdelkov",
+    "emptyCart": "Vaša košarica je prazna",
+    "remove": "Odstrani",
+    "price": "Cena na enoto",
+    "finalPriceInCheckoutText": "Vsi veljavni davki in stroški dostave bodo izračunani ob blagajni",
+    "subtotal": "Delna vsota",
+    "discount": "Popust",
+    "giftCard": "Darilna kartica",
+    "shippingAmount": "Dostava",
+    "paymentMethodAmount": "Način plačila",
+    "total": "Skupaj",
+    "gotToCheckoutCta": "Blagajna",
+    "returnUrlLabel": "Nadaljuj z nakupovanjem",
+    "quantityNotAvailable": "Izbrana količina ni na voljo",
+    "retryableErrorCode": "Težave s povezavo",
+    "retryableErrorDescription": "Poskusite znova naložiti stran"
+  },
+  "item": {
+    "frequency": {
+      "hourly": "Vsako uro",
+      "daily": "Dnevno",
+      "weekly": "Tedensko",
+      "monthly": "Mesečno",
+      "two-months": "Vsaka dva meseca",
+      "two-month": "Vsaka dva meseca",
+      "three-months": "Vsake tri mesece",
+      "three-month": "Vsake tri mesece",
+      "four-months": "Vsake štiri mesece",
+      "four-month": "Vsake štiri mesece",
+      "six-months": "Vsakih šest mesecev",
+      "six-month": "Vsakih šest mesecev",
+      "yearly": "Letno"
+    }
+  },
+  "couponOrGift": {
+    "label": "Imate promocijsko kodo?",
+    "submit": "Uporabi",
+    "placeholder": {
+      "gift_card_or_coupon_code": "Koda darilne kartice ali kupona",
+      "gift_card_code": "Koda darilne kartice",
+      "coupon_code": "Koda kupona"
+    },
+    "error": {
+      "gift_card_or_coupon_code": "Vnesite veljavno darilno kartico ali kupon",
+      "gift_card_code": "Vnesite veljavno darilno kartico",
+      "coupon_code": "Vnesite veljaven kupon"
+    }
+  }
+}

--- a/packages/cart/src/components/i18n/index.ts
+++ b/packages/cart/src/components/i18n/index.ts
@@ -7,11 +7,15 @@ import {
 
 import commonDe from "#assets/locales/de/common.json"
 import commonEn from "#assets/locales/en/common.json"
+import commonEs from "#assets/locales/es/common.json"
+import commonFr from "#assets/locales/fr/common.json"
+import commonHr from "#assets/locales/hr/common.json"
 import commonHu from "#assets/locales/hu/common.json"
 import commonIt from "#assets/locales/it/common.json"
 import commonNl from "#assets/locales/nl/common.json"
 import commonPl from "#assets/locales/pl/common.json"
 import commonPt from "#assets/locales/pt/common.json"
+import commonSl from "#assets/locales/sl/common.json"
 
 const resources: Record<AllowedLocaleKeys, AppResources> = {
   en: {
@@ -34,6 +38,18 @@ const resources: Record<AllowedLocaleKeys, AppResources> = {
   },
   nl: {
     common: commonNl,
+  },
+  es: {
+    common: commonEs,
+  },
+  fr: {
+    common: commonFr,
+  },
+  hr: {
+    common: commonHr,
+  },
+  sl: {
+    common: commonSl,
   },
 }
 

--- a/packages/cart/src/components/i18n/parseLanguageCode.ts
+++ b/packages/cart/src/components/i18n/parseLanguageCode.ts
@@ -1,6 +1,6 @@
 import type { AllowedLocaleKeys } from "react-i18next"
 
-type ApiLanguageCode = "en" | "it" | "de" | "pl" | "hu" | "pt" | "nl"
+type ApiLanguageCode = "en" | "it" | "de" | "pl" | "hu" | "pt" | "nl" | "es" | "fr" | "hr" | "sl"
 
 const langs: Record<ApiLanguageCode, AllowedLocaleKeys> = {
   en: "en",
@@ -10,6 +10,10 @@ const langs: Record<ApiLanguageCode, AllowedLocaleKeys> = {
   hu: "hu",
   pt: "pt",
   nl: "nl",
+  es: "es",
+  fr: "fr",
+  hr: "hr",
+  sl: "sl",
 }
 
 export const parseLanguageCode = (apiLanguageCode: string) =>


### PR DESCRIPTION
Closes #132

## What I did

This PR adds localization support for 4 additional languages to bring feature parity with the mfe-checkout and mfe-microstore applications:

- Spanish (`es`)
- French (`fr`)
- Croatian (`hr`)
- Slovenian (`sl`)

All language files follow the same JSON structure as the existing English locale and include translations for all keys in the `common` namespace:

- General cart labels (title, item count, subtotal, total, etc.)
- Subscription frequency labels
- Coupon/gift card section

The i18n configuration, type declarations, and language code parser have been updated to register all new languages.

## How to test

1. Change the language code in the application settings (or set `language_code` on an order) to any of the new languages (`es`, `fr`, `hr`, `sl`)
2. Verify that all UI text elements are properly translated
3. Run the e2e language spec — new test cases for all 4 languages have been added

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.